### PR TITLE
Fix nightly 2026-03-17

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2026-03-17"

--- a/src/alternative/builder.rs
+++ b/src/alternative/builder.rs
@@ -14,7 +14,11 @@ pub trait Builder<S> {
 pub struct DefaultBuilder;
 
 impl<S: Default> Builder<S> for DefaultBuilder {
-    fn from_storage(_: S) -> Self { Self::default() }
+    fn from_storage(_: S) -> Self {
+        Self::default()
+    }
 
-    fn into_storage(self) -> S { S::default() }
+    fn into_storage(self) -> S {
+        S::default()
+    }
 }

--- a/src/alternative/inner.rs
+++ b/src/alternative/inner.rs
@@ -13,16 +13,18 @@ pub(crate) enum Inner<F, S, FB, SB> {
 
 impl<F, S, FB, SB> Inner<F, S, FB, SB> {
     pub(crate) fn first(value: F, builder: SB) -> Self {
-        Self::First(InnerElement{ value, builder })
+        Self::First(InnerElement { value, builder })
     }
 
     pub(crate) fn second(value: S, builder: FB) -> Self {
-        Self::Second(InnerElement{ value, builder })
+        Self::Second(InnerElement { value, builder })
     }
 }
 
 impl<F: Default, S, FB, SB: Default> Default for Inner<F, S, FB, SB> {
-    fn default() -> Self { Self::First(InnerElement::default()) }
+    fn default() -> Self {
+        Self::First(InnerElement::default())
+    }
 }
 
 //  Element of alternative type.
@@ -34,26 +36,36 @@ pub(crate) struct InnerElement<V, B> {
 
 impl<V, B> InnerElement<V, B> {
     pub(crate) fn transform<OV, OB, Fun, R>(self, fun: Fun) -> (InnerElement<OV, OB>, R)
-        where
-            B: Builder<OV>,
-            OB: Builder<V>,
-            Fun: FnOnce(&mut V, &mut OV) -> R,
+    where
+        B: Builder<OV>,
+        OB: Builder<V>,
+        Fun: FnOnce(&mut V, &mut OV) -> R,
     {
         let InnerElement { mut value, builder } = self;
         let mut other_value = B::into_storage(builder);
         let result = fun(&mut value, &mut other_value);
         let other_builder = OB::from_storage(value);
 
-        (InnerElement { value: other_value, builder: other_builder }, result)
+        (
+            InnerElement {
+                value: other_value,
+                builder: other_builder,
+            },
+            result,
+        )
     }
 }
 
 impl<V, B> Deref for InnerElement<V, B> {
     type Target = V;
 
-    fn deref(&self) -> &Self::Target { &self.value }
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
 }
 
 impl<V, B> DerefMut for InnerElement<V, B> {
-    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.value }
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
 }

--- a/src/alternative/single_range.rs
+++ b/src/alternative/single_range.rs
@@ -1,6 +1,13 @@
 //! Alternative implementation of `SingleRangeStorage`.
 
-use core::{alloc::AllocError, cmp, fmt::{self, Debug}, hint, mem::{self, MaybeUninit}, ptr::{self, NonNull}};
+use core::{
+    alloc::AllocError,
+    cmp,
+    fmt::{self, Debug},
+    hint,
+    mem::{self, MaybeUninit},
+    ptr::{self, NonNull},
+};
 
 use crate::traits::{Capacity, RangeStorage, SingleRangeStorage};
 
@@ -14,18 +21,22 @@ pub struct SingleRange<F, S, FB, SB>(Inner<F, S, FB, SB>);
 
 impl<F, S, FB, SB> SingleRange<F, S, FB, SB> {
     /// Creates an instance containing the First alternative.
-    pub fn first(first: F, second_builder: SB) -> Self { Self(Inner::first(first, second_builder)) }
+    pub fn first(first: F, second_builder: SB) -> Self {
+        Self(Inner::first(first, second_builder))
+    }
 
     /// Creates an instance containing the Second alternative.
-    pub fn second(second: S, first_builder: FB) -> Self { Self(Inner::second(second, first_builder)) }
+    pub fn second(second: S, first_builder: FB) -> Self {
+        Self(Inner::second(second, first_builder))
+    }
 }
 
 impl<F, S, FB, SB> RangeStorage for SingleRange<F, S, FB, SB>
-    where
-        F: SingleRangeStorage,
-        S: SingleRangeStorage,
-        FB: Builder<F>,
-        SB: Builder<S>,
+where
+    F: SingleRangeStorage,
+    S: SingleRangeStorage,
+    FB: Builder<F>,
+    SB: Builder<S>,
 {
     type Handle<T> = SingleRangeHandle<F::Handle<T>, S::Handle<T>>;
 
@@ -63,7 +74,11 @@ impl<F, S, FB, SB> RangeStorage for SingleRange<F, S, FB, SB>
         }
     }
 
-    unsafe fn try_grow<T>(&mut self, handle: Self::Handle<T>, new_capacity: Self::Capacity) -> Result<Self::Handle<T>, AllocError> {
+    unsafe fn try_grow<T>(
+        &mut self,
+        handle: Self::Handle<T>,
+        new_capacity: Self::Capacity,
+    ) -> Result<Self::Handle<T>, AllocError> {
         match &mut self.0 {
             Inner::First(ref mut first) => {
                 let grow = into_first::<F, S>(new_capacity)
@@ -73,79 +88,94 @@ impl<F, S, FB, SB> RangeStorage for SingleRange<F, S, FB, SB>
                     Ok(first) => Ok(SingleRangeHandle { first }),
                     Err(_) => {
                         if let Inner::First(first) = mem::replace(&mut self.0, Inner::Poisoned) {
-                            let (second, result) = first.transform(|first: &mut F, second: &mut S| {
-                                let new_handle = second.allocate(new_capacity)?;
-                                transfer(first.resolve_mut(handle.first), second.resolve_mut(new_handle));
-                                Ok(SingleRangeHandle { second: new_handle })
-                            });
+                            let (second, result) =
+                                first.transform(|first: &mut F, second: &mut S| {
+                                    let new_handle = second.allocate(new_capacity)?;
+                                    transfer(
+                                        first.resolve_mut(handle.first),
+                                        second.resolve_mut(new_handle),
+                                    );
+                                    Ok(SingleRangeHandle { second: new_handle })
+                                });
                             self.0 = Inner::Second(second);
                             return result;
                         }
                         //  Safety:
                         //  -   self.0 was First before invoking replace, hence replace returns First.
                         hint::unreachable_unchecked();
-                    },
+                    }
                 }
-            },
-            Inner::Second(ref mut second) =>
-                second.try_grow(handle.second, new_capacity).map(|second| SingleRangeHandle{ second }),
+            }
+            Inner::Second(ref mut second) => second
+                .try_grow(handle.second, new_capacity)
+                .map(|second| SingleRangeHandle { second }),
             Inner::Poisoned => panic!("Poisoned"),
         }
     }
 
-    unsafe fn try_shrink<T>(&mut self, handle: Self::Handle<T>, new_capacity: Self::Capacity) -> Result<Self::Handle<T>, AllocError> {
+    unsafe fn try_shrink<T>(
+        &mut self,
+        handle: Self::Handle<T>,
+        new_capacity: Self::Capacity,
+    ) -> Result<Self::Handle<T>, AllocError> {
         match &mut self.0 {
-            Inner::First(ref mut first) =>
-                first.try_shrink(handle.first, into_first::<F, S>(new_capacity)?)
-                    .map(|first| SingleRangeHandle{ first }),
+            Inner::First(ref mut first) => first
+                .try_shrink(handle.first, into_first::<F, S>(new_capacity)?)
+                .map(|first| SingleRangeHandle { first }),
 
             Inner::Second(ref mut second) => {
                 let shrink = second.try_shrink(handle.second, new_capacity);
 
                 match shrink {
-                    Ok(second) => Ok(SingleRangeHandle{ second }),
+                    Ok(second) => Ok(SingleRangeHandle { second }),
                     Err(_) => {
                         let new_capacity = into_first::<F, S>(new_capacity)?;
 
                         if let Inner::Second(second) = mem::replace(&mut self.0, Inner::Poisoned) {
-                            let (first, result) = second.transform(|second: &mut S, first: &mut F| {
-                                let new_handle = first.allocate(new_capacity)?;
-                                transfer(second.resolve_mut(handle.second), first.resolve_mut(new_handle));
-                                Ok(SingleRangeHandle { first: new_handle })
-                            });
+                            let (first, result) =
+                                second.transform(|second: &mut S, first: &mut F| {
+                                    let new_handle = first.allocate(new_capacity)?;
+                                    transfer(
+                                        second.resolve_mut(handle.second),
+                                        first.resolve_mut(new_handle),
+                                    );
+                                    Ok(SingleRangeHandle { first: new_handle })
+                                });
                             self.0 = Inner::First(first);
                             return result;
                         }
                         //  Safety:
                         //  -   self.0 was Second before invoking replace, hence replace returns Second.
                         hint::unreachable_unchecked();
-                    },
+                    }
                 }
-            },
+            }
             Inner::Poisoned => panic!("Poisoned"),
         }
     }
 }
 
 impl<F, S, FB, SB> SingleRangeStorage for SingleRange<F, S, FB, SB>
-    where
-        F: SingleRangeStorage,
-        S: SingleRangeStorage,
-        FB: Builder<F>,
-        SB: Builder<S>,
+where
+    F: SingleRangeStorage,
+    S: SingleRangeStorage,
+    FB: Builder<F>,
+    SB: Builder<S>,
 {
     fn allocate<T>(&mut self, capacity: Self::Capacity) -> Result<Self::Handle<T>, AllocError> {
         match &mut self.0 {
             Inner::First(ref mut first) => {
-                let handle = into_first::<F, S>(capacity)
-                    .and_then(|capacity| first.allocate(capacity));
+                let handle =
+                    into_first::<F, S>(capacity).and_then(|capacity| first.allocate(capacity));
 
                 match handle {
-                    Ok(first) => Ok(SingleRangeHandle{ first }),
+                    Ok(first) => Ok(SingleRangeHandle { first }),
                     Err(_) => {
                         if let Inner::First(first) = mem::replace(&mut self.0, Inner::Poisoned) {
                             let (second, result) = first.transform(|_, second: &mut S| {
-                                second.allocate(capacity).map(|second| SingleRangeHandle { second })
+                                second
+                                    .allocate(capacity)
+                                    .map(|second| SingleRangeHandle { second })
                             });
                             self.0 = Inner::Second(second);
                             return result;
@@ -155,9 +185,10 @@ impl<F, S, FB, SB> SingleRangeStorage for SingleRange<F, S, FB, SB>
                         unsafe { hint::unreachable_unchecked() };
                     }
                 }
-            },
-            Inner::Second(ref mut second) =>
-                second.allocate(capacity).map(|second| SingleRangeHandle{ second }),
+            }
+            Inner::Second(ref mut second) => second
+                .allocate(capacity)
+                .map(|second| SingleRangeHandle { second }),
             Inner::Poisoned => panic!("Poisoned"),
         }
     }
@@ -170,7 +201,9 @@ impl<F, S, FB, SB> Debug for SingleRange<F, S, FB, SB> {
 }
 
 impl<F: Default, S, FB, SB: Default> Default for SingleRange<F, S, FB, SB> {
-    fn default() -> Self { Self(Inner::default()) }
+    fn default() -> Self {
+        Self(Inner::default())
+    }
 }
 
 /// SingleRangeHandle, an alternative between 2 handles.
@@ -190,9 +223,10 @@ impl<F: Copy, S: Copy> Debug for SingleRangeHandle<F, S> {
 //  Implementation
 //
 
-fn into_first<F: RangeStorage, S: RangeStorage>(capacity: S::Capacity) -> Result<F::Capacity, AllocError> {
-    F::Capacity::from_usize(capacity.into_usize())
-        .ok_or(AllocError)
+fn into_first<F: RangeStorage, S: RangeStorage>(
+    capacity: S::Capacity,
+) -> Result<F::Capacity, AllocError> {
+    F::Capacity::from_usize(capacity.into_usize()).ok_or(AllocError)
 }
 
 fn into_second<F: RangeStorage, S: RangeStorage>(capacity: F::Capacity) -> S::Capacity {
@@ -204,5 +238,9 @@ unsafe fn transfer<T>(from: NonNull<[MaybeUninit<T>]>, mut to: NonNull<[MaybeUni
     let from = from.as_ref();
     let to = to.as_mut();
 
-    ptr::copy_nonoverlapping(from.as_ptr(), to.as_mut_ptr(), cmp::min(from.len(), to.len()));
+    ptr::copy_nonoverlapping(
+        from.as_ptr(),
+        to.as_mut_ptr(),
+        cmp::min(from.len(), to.len()),
+    );
 }

--- a/src/collections/raw_box.rs
+++ b/src/collections/raw_box.rs
@@ -21,7 +21,10 @@ impl<T: Pointee, S: SingleElementStorage> RawBox<T, S> {
     /// Creates an instance of Self, containing `value` stored in `storage`.
     pub fn new(value: T, mut storage: S) -> Result<Self, (T, S)> {
         match storage.create(value) {
-            Ok(handle) => Ok(RawBox { storage: ManuallyDrop::new(storage), handle }),
+            Ok(handle) => Ok(RawBox {
+                storage: ManuallyDrop::new(storage),
+                handle,
+            }),
             Err(value) => Err((value, storage)),
         }
     }
@@ -32,8 +35,8 @@ impl<T: ?Sized + Pointee, S: SingleElementStorage> RawBox<T, S> {
     ///
     /// A poor's man CoerceUnsized implementation, for now.
     pub fn coerce<U: ?Sized>(mut self) -> RawBox<U, S>
-        where
-            T: Unsize<U>,
+    where
+        T: Unsize<U>,
     {
         //  Safety:
         //  -   `self.handle` is valid.
@@ -44,13 +47,19 @@ impl<T: ?Sized + Pointee, S: SingleElementStorage> RawBox<T, S> {
         let storage = unsafe { ManuallyDrop::take(&mut self.storage) };
         mem::forget(self);
 
-        RawBox { storage: ManuallyDrop::new(storage), handle, }
+        RawBox {
+            storage: ManuallyDrop::new(storage),
+            handle,
+        }
     }
 
     /// Switch to another storage, if possible.
-    pub fn try_in<NS: SingleElementStorage>(this: Self, mut new_storage: NS) -> Result<RawBox<T, NS>, RawBox<T, S>> {
+    pub fn try_in<NS: SingleElementStorage>(
+        this: Self,
+        mut new_storage: NS,
+    ) -> Result<RawBox<T, NS>, RawBox<T, S>> {
         let layout = Layout::for_value(&*this);
-        let (data, meta) =  NonNull::from(&*this).to_raw_parts();
+        let (data, meta) = NonNull::from(&*this).to_raw_parts();
 
         let new_handle = match new_storage.allocate::<T>(meta) {
             Ok(new_handle) => new_handle,
@@ -72,22 +81,31 @@ impl<T: ?Sized + Pointee, S: SingleElementStorage> RawBox<T, S> {
 
         //  Safety:
         //  -   `new_data` is suitable for `layout`.
-        unsafe { ptr::copy_nonoverlapping(data.as_ptr() as *const u8, new_data.as_ptr() as *mut u8, layout.size()) };
+        unsafe {
+            ptr::copy_nonoverlapping(
+                data.as_ptr() as *const u8,
+                new_data.as_ptr() as *mut u8,
+                layout.size(),
+            )
+        };
 
         //  Safety:
         //  -   `old_handle` is valid.
         unsafe { old_storage.deallocate(old_handle) };
 
-        Ok(RawBox{ handle: new_handle, storage: ManuallyDrop::new(new_storage) })
+        Ok(RawBox {
+            handle: new_handle,
+            storage: ManuallyDrop::new(new_storage),
+        })
     }
 }
 
 impl<T, U, S> CoerceUnsized<RawBox<U, S>> for RawBox<T, S>
-    where
-        T: ?Sized + Pointee,
-        U: ?Sized + Pointee,
-        S: SingleElementStorage,
-        S::Handle<T>: CoerceUnsized<S::Handle<U>>,
+where
+    T: ?Sized + Pointee,
+    U: ?Sized + Pointee,
+    S: SingleElementStorage,
+    S::Handle<T>: CoerceUnsized<S::Handle<U>>,
 {
 }
 
@@ -139,292 +157,289 @@ impl<T: ?Sized + Pointee + Debug, S: SingleElementStorage> Debug for RawBox<T, S
 #[cfg(test)]
 mod test_inline {
 
-use crate::inline::SingleElement;
+    use crate::inline::SingleElement;
 
-use super::*;
+    use super::*;
 
-#[test]
-fn sized_storage() {
-    let storage = SingleElement::<u8>::new();
-    let mut boxed = RawBox::new(1u8, storage).unwrap();
+    #[test]
+    fn sized_storage() {
+        let storage = SingleElement::<u8>::new();
+        let mut boxed = RawBox::new(1u8, storage).unwrap();
 
-    assert_eq!(1u8, *boxed);
+        assert_eq!(1u8, *boxed);
 
-    *boxed = 2;
+        *boxed = 2;
 
-    assert_eq!(2u8, *boxed);
-}
+        assert_eq!(2u8, *boxed);
+    }
 
-#[test]
-fn slice_storage() {
-    let storage = SingleElement::<[u8; 4]>::new();
-    let mut boxed: RawBox<[u8], _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
+    #[test]
+    fn slice_storage() {
+        let storage = SingleElement::<[u8; 4]>::new();
+        let mut boxed: RawBox<[u8], _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
 
-    assert_eq!([1u8, 2, 3], &*boxed);
+        assert_eq!([1u8, 2, 3], &*boxed);
 
-    boxed[2] = 4;
+        boxed[2] = 4;
 
-    assert_eq!([1u8, 2, 4], &*boxed);
-}
+        assert_eq!([1u8, 2, 4], &*boxed);
+    }
 
-#[test]
-fn trait_storage() {
-    let storage = SingleElement::<[u8; 4]>::new();
-    let boxed: RawBox<dyn Debug, _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
+    #[test]
+    fn trait_storage() {
+        let storage = SingleElement::<[u8; 4]>::new();
+        let boxed: RawBox<dyn Debug, _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
 
-    assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", boxed));
-}
-
+        assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", boxed));
+    }
 } // mod test_inline
 
 #[cfg(test)]
 mod test_small {
 
-use crate::small::SingleElement;
-use crate::utils::{NonAllocator, SpyAllocator};
+    use crate::small::SingleElement;
+    use crate::utils::{NonAllocator, SpyAllocator};
 
-use super::*;
+    use super::*;
 
-#[test]
-fn sized_inline() {
-    let storage = SingleElement::<u8, _>::new(NonAllocator);
-    let mut boxed = RawBox::new(1u8, storage).unwrap();
+    #[test]
+    fn sized_inline() {
+        let storage = SingleElement::<u8, _>::new(NonAllocator);
+        let mut boxed = RawBox::new(1u8, storage).unwrap();
 
-    assert_eq!(1u8, *boxed);
+        assert_eq!(1u8, *boxed);
 
-    *boxed = 2;
+        *boxed = 2;
 
-    assert_eq!(2u8, *boxed);
-}
+        assert_eq!(2u8, *boxed);
+    }
 
-#[test]
-fn sized_allocated() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn sized_allocated() {
+        let allocator = SpyAllocator::default();
 
-    let storage = SingleElement::<u8, _>::new(allocator.clone());
-    let mut boxed = RawBox::new(1u32, storage).unwrap();
+        let storage = SingleElement::<u8, _>::new(allocator.clone());
+        let mut boxed = RawBox::new(1u32, storage).unwrap();
 
-    assert_eq!(1u32, *boxed);
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!(1u32, *boxed);
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    *boxed = 2;
+        *boxed = 2;
 
-    assert_eq!(2u32, *boxed);
+        assert_eq!(2u32, *boxed);
 
-    drop(boxed);
+        drop(boxed);
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 
-#[test]
-fn sized_failure() {
-    let storage = SingleElement::<u8, _>::new(NonAllocator);
-    RawBox::new(1, storage).unwrap_err();
-}
+    #[test]
+    fn sized_failure() {
+        let storage = SingleElement::<u8, _>::new(NonAllocator);
+        RawBox::new(1, storage).unwrap_err();
+    }
 
-#[test]
-fn slice_inline() {
-    let storage = SingleElement::<[u8; 4], _>::new(NonAllocator);
-    let mut boxed : RawBox<[u8], _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
+    #[test]
+    fn slice_inline() {
+        let storage = SingleElement::<[u8; 4], _>::new(NonAllocator);
+        let mut boxed: RawBox<[u8], _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
 
-    assert_eq!([1u8, 2, 3], &*boxed);
+        assert_eq!([1u8, 2, 3], &*boxed);
 
-    boxed[2] = 4;
+        boxed[2] = 4;
 
-    assert_eq!([1u8, 2, 4], &*boxed);
-}
+        assert_eq!([1u8, 2, 4], &*boxed);
+    }
 
-#[test]
-fn slice_allocated() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn slice_allocated() {
+        let allocator = SpyAllocator::default();
 
-    let storage = SingleElement::<[u8; 2], _>::new(allocator.clone());
-    let mut boxed : RawBox<[u8], _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
+        let storage = SingleElement::<[u8; 2], _>::new(allocator.clone());
+        let mut boxed: RawBox<[u8], _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
 
-    assert_eq!([1u8, 2, 3], &*boxed);
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!([1u8, 2, 3], &*boxed);
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    boxed[2] = 4;
+        boxed[2] = 4;
 
-    assert_eq!([1u8, 2, 4], &*boxed);
+        assert_eq!([1u8, 2, 4], &*boxed);
 
-    drop(boxed);
+        drop(boxed);
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 
-#[test]
-fn slice_failure() {
-    let storage = SingleElement::<[u8; 2], _>::new(NonAllocator);
-    RawBox::new([1u8, 2, 3], storage).unwrap_err();
-}
+    #[test]
+    fn slice_failure() {
+        let storage = SingleElement::<[u8; 2], _>::new(NonAllocator);
+        RawBox::new([1u8, 2, 3], storage).unwrap_err();
+    }
 
-#[test]
-fn trait_inline() {
-    let storage = SingleElement::<[u8; 4], _>::new(NonAllocator);
-    let boxed : RawBox<dyn Debug, _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
+    #[test]
+    fn trait_inline() {
+        let storage = SingleElement::<[u8; 4], _>::new(NonAllocator);
+        let boxed: RawBox<dyn Debug, _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
 
-    assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", boxed));
-}
+        assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", boxed));
+    }
 
-#[test]
-fn trait_allocated() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn trait_allocated() {
+        let allocator = SpyAllocator::default();
 
-    let storage = SingleElement::<[u8; 2], _>::new(allocator.clone());
-    let boxed : RawBox<dyn Debug, _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
+        let storage = SingleElement::<[u8; 2], _>::new(allocator.clone());
+        let boxed: RawBox<dyn Debug, _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
 
-    assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", boxed));
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", boxed));
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    drop(boxed);
+        drop(boxed);
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 
-#[test]
-fn trait_failure() {
-    let storage = SingleElement::<[u8; 2], _>::new(NonAllocator);
-    RawBox::new([1u8, 2, 3], storage).unwrap_err();
-}
-
+    #[test]
+    fn trait_failure() {
+        let storage = SingleElement::<[u8; 2], _>::new(NonAllocator);
+        RawBox::new([1u8, 2, 3], storage).unwrap_err();
+    }
 } // mod test_small
 
 #[cfg(test)]
 mod test_allocator {
 
-use crate::allocator::SingleElement;
-use crate::utils::{NonAllocator, SpyAllocator};
+    use crate::allocator::SingleElement;
+    use crate::utils::{NonAllocator, SpyAllocator};
 
-use super::*;
+    use super::*;
 
-#[test]
-fn sized_allocated() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn sized_allocated() {
+        let allocator = SpyAllocator::default();
 
-    let storage = SingleElement::new(allocator.clone());
-    let mut boxed = RawBox::new(1, storage).unwrap();
+        let storage = SingleElement::new(allocator.clone());
+        let mut boxed = RawBox::new(1, storage).unwrap();
 
-    assert_eq!(1u32, *boxed);
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!(1u32, *boxed);
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    *boxed = 2;
+        *boxed = 2;
 
-    assert_eq!(2u32, *boxed);
+        assert_eq!(2u32, *boxed);
 
-    drop(boxed);
+        drop(boxed);
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 
-#[test]
-fn sized_failure() {
-    let storage = SingleElement::new(NonAllocator);
-    RawBox::new(1, storage).unwrap_err();
-}
+    #[test]
+    fn sized_failure() {
+        let storage = SingleElement::new(NonAllocator);
+        RawBox::new(1, storage).unwrap_err();
+    }
 
-#[test]
-fn slice_allocated() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn slice_allocated() {
+        let allocator = SpyAllocator::default();
 
-    let storage = SingleElement::new(allocator.clone());
-    let mut boxed : RawBox<[u8], _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
+        let storage = SingleElement::new(allocator.clone());
+        let mut boxed: RawBox<[u8], _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
 
-    assert_eq!([1u8, 2, 3], &*boxed);
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!([1u8, 2, 3], &*boxed);
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    boxed[2] = 4;
+        boxed[2] = 4;
 
-    assert_eq!([1u8, 2, 4], &*boxed);
+        assert_eq!([1u8, 2, 4], &*boxed);
 
-    drop(boxed);
+        drop(boxed);
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 
-#[test]
-fn slice_failure() {
-    let storage = SingleElement::new(NonAllocator);
-    RawBox::new([1u8, 2, 3], storage).unwrap_err();
-}
+    #[test]
+    fn slice_failure() {
+        let storage = SingleElement::new(NonAllocator);
+        RawBox::new([1u8, 2, 3], storage).unwrap_err();
+    }
 
-#[test]
-fn slice_coerce() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn slice_coerce() {
+        let allocator = SpyAllocator::default();
 
-    let storage = SingleElement::new(allocator.clone());
-    let boxed = RawBox::new([1u8, 2, 3], storage).unwrap();
+        let storage = SingleElement::new(allocator.clone());
+        let boxed = RawBox::new([1u8, 2, 3], storage).unwrap();
 
-    assert_eq!([1u8, 2, 3], *boxed);
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!([1u8, 2, 3], *boxed);
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    //  FIXME: ICE...
-    //  let coerced : RawBox<[u8], _> = boxed;
-    let coerced : RawBox<[u8], _> = boxed.coerce();
+        //  FIXME: ICE...
+        //  let coerced : RawBox<[u8], _> = boxed;
+        let coerced: RawBox<[u8], _> = boxed.coerce();
 
-    assert_eq!([1u8, 2, 3], *coerced);
+        assert_eq!([1u8, 2, 3], *coerced);
 
-    drop(coerced);
+        drop(coerced);
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 
-#[test]
-fn trait_allocated() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn trait_allocated() {
+        let allocator = SpyAllocator::default();
 
-    let storage = SingleElement::new(allocator.clone());
-    let boxed : RawBox<dyn Debug, _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
+        let storage = SingleElement::new(allocator.clone());
+        let boxed: RawBox<dyn Debug, _> = RawBox::new([1u8, 2, 3], storage).unwrap().coerce();
 
-    assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", boxed));
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", boxed));
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    drop(boxed);
+        drop(boxed);
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 
-#[test]
-fn trait_failure() {
-    let storage = SingleElement::new(NonAllocator);
-    RawBox::new([1u8, 2, 3], storage).unwrap_err();
-}
+    #[test]
+    fn trait_failure() {
+        let storage = SingleElement::new(NonAllocator);
+        RawBox::new([1u8, 2, 3], storage).unwrap_err();
+    }
 
-#[test]
-fn trait_coerce() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn trait_coerce() {
+        let allocator = SpyAllocator::default();
 
-    let storage = SingleElement::new(allocator.clone());
-    let boxed = RawBox::new([1u8, 2, 3], storage).unwrap();
+        let storage = SingleElement::new(allocator.clone());
+        let boxed = RawBox::new([1u8, 2, 3], storage).unwrap();
 
-    assert_eq!([1u8, 2, 3], *boxed);
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!([1u8, 2, 3], *boxed);
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    //  FIXME: ICE
-    //  let coerced : RawBox<dyn Debug, _> = boxed;
-    let coerced : RawBox<dyn Debug, _> = boxed.coerce();
+        //  FIXME: ICE
+        //  let coerced : RawBox<dyn Debug, _> = boxed;
+        let coerced: RawBox<dyn Debug, _> = boxed.coerce();
 
-    assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", coerced));
+        assert_eq!("RawBox{ [1, 2, 3] }", format!("{:?}", coerced));
 
-    drop(coerced);
+        drop(coerced);
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
-
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 } // mod test_allocator

--- a/src/collections/raw_vec.rs
+++ b/src/collections/raw_vec.rs
@@ -1,6 +1,12 @@
 //! Proof-of-Concept implementation of a Vec parameterized by a Storage.
 
-use core::{cmp, fmt::{self, Debug}, mem::MaybeUninit, ops::{Deref, DerefMut}, ptr};
+use core::{
+    cmp,
+    fmt::{self, Debug},
+    mem::MaybeUninit,
+    ops::{Deref, DerefMut},
+    ptr,
+};
 
 use crate::traits::{Capacity, SingleRangeStorage};
 
@@ -17,16 +23,22 @@ impl<T, S: SingleRangeStorage> RawVec<T, S> {
         let zero = Self::into_capacity(0);
 
         let len = zero;
-        let data = storage.allocate(zero).expect("Zero-capacity allocation should always succeed");
+        let data = storage
+            .allocate(zero)
+            .expect("Zero-capacity allocation should always succeed");
 
-        Self { len, data, storage, }
+        Self { len, data, storage }
     }
 
     /// Returns whether `self` is empty, or not.
-    pub fn is_empty(&self) -> bool { self.len() == 0 }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 
     /// Returns the number of elements in `self`.
-    pub fn len(&self) -> usize { self.len.into_usize() }
+    pub fn len(&self) -> usize {
+        self.len.into_usize()
+    }
 
     /// Clears `self`, destroying all elements and resetting its length to 0.
     pub fn clear(&mut self) {
@@ -99,7 +111,9 @@ impl<T: Debug, S: SingleRangeStorage> Debug for RawVec<T, S> {
 }
 
 impl<T, S: Default + SingleRangeStorage> Default for RawVec<T, S> {
-    fn default() -> Self { RawVec::new(S::default()) }
+    fn default() -> Self {
+        RawVec::new(S::default())
+    }
 }
 
 impl<T, S: SingleRangeStorage> Deref for RawVec<T, S> {
@@ -115,7 +129,7 @@ impl<T, S: SingleRangeStorage> Deref for RawVec<T, S> {
 
         //  Safety:
         //  -   Invariant, `self.raw_slice()[0..len]` are initialized.
-        unsafe { MaybeUninit::slice_assume_init_ref(slice) }
+        unsafe { slice.assume_init_ref() }
     }
 }
 
@@ -130,7 +144,7 @@ impl<T, S: SingleRangeStorage> DerefMut for RawVec<T, S> {
 
         //  Safety:
         //  -   Invariant, `self.raw_slice()[0..len]` are initialized.
-        unsafe { MaybeUninit::slice_assume_init_mut(slice) }
+        unsafe { slice.assume_init_mut() }
     }
 }
 
@@ -182,7 +196,10 @@ impl<T, S: SingleRangeStorage> RawVec<T, S> {
 
         //  Safety:
         //  -   `self.data` is a valid handle pointing to valid data.
-        self.data = match unsafe { self.storage.try_grow(self.data, Self::into_capacity(new_cap)) } {
+        self.data = match unsafe {
+            self.storage
+                .try_grow(self.data, Self::into_capacity(new_cap))
+        } {
             Ok(handle) => handle,
             Err(_) => return Err(e),
         };
@@ -204,110 +221,108 @@ impl<T, S: SingleRangeStorage> RawVec<T, S> {
 #[cfg(test)]
 mod test_inline {
 
-use core::mem;
+    use core::mem;
 
-use crate::inline::SingleRange;
+    use crate::inline::SingleRange;
 
-use super::*;
+    use super::*;
 
-#[test]
-fn size() {
-    type Storage = SingleRange<u8, u8, 31>;
-    type Vec = RawVec<u8, Storage>;
+    #[test]
+    fn size() {
+        type Storage = SingleRange<u8, u8, 31>;
+        type Vec = RawVec<u8, Storage>;
 
-    assert_eq!(32, mem::size_of::<Vec>());
-}
-
-#[test]
-fn smoke_test() {
-    type Storage = SingleRange<u8, u8, 31>;
-    type Vec = RawVec<u8, Storage>;
-
-    let mut vec = Vec::default();
-
-    for i in 0..31 {
-        vec.push(i);
+        assert_eq!(32, mem::size_of::<Vec>());
     }
 
-    assert_eq!(Some(&2), vec.get(2));
+    #[test]
+    fn smoke_test() {
+        type Storage = SingleRange<u8, u8, 31>;
+        type Vec = RawVec<u8, Storage>;
 
-    assert_eq!(
+        let mut vec = Vec::default();
+
+        for i in 0..31 {
+            vec.push(i);
+        }
+
+        assert_eq!(Some(&2), vec.get(2));
+
+        assert_eq!(
         "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]",
         format!("{:?}", vec)
     );
-}
+    }
 
-#[test]
-fn try_push_failure() {
-    type Storage = SingleRange<u8, u8, 1>;
-    type Vec = RawVec<u8, Storage>;
+    #[test]
+    fn try_push_failure() {
+        type Storage = SingleRange<u8, u8, 1>;
+        type Vec = RawVec<u8, Storage>;
 
-    let mut vec = Vec::default();
-    vec.push(0);
+        let mut vec = Vec::default();
+        vec.push(0);
 
-    assert_eq!(Err(42), vec.try_push(42));
-}
-
+        assert_eq!(Err(42), vec.try_push(42));
+    }
 } // mod test_inline
 
 #[cfg(test)]
 mod test_allocator {
 
-use core::mem;
+    use core::mem;
 
-use crate::allocator::SingleRange;
-use crate::utils::{NonAllocator, SpyAllocator};
+    use crate::allocator::SingleRange;
+    use crate::utils::{NonAllocator, SpyAllocator};
 
-use super::*;
+    use super::*;
 
-#[test]
-fn size() {
-    type Storage = SingleRange<NonAllocator>;
-    type Vec = RawVec<u8, Storage>;
+    #[test]
+    fn size() {
+        type Storage = SingleRange<NonAllocator>;
+        type Vec = RawVec<u8, Storage>;
 
-    assert_eq!(mem::size_of::<usize>() * 3, mem::size_of::<Vec>());
-}
-
-#[test]
-fn smoke_test() {
-    type Storage = SingleRange<SpyAllocator>;
-    type Vec = RawVec<u8, Storage>;
-
-    let allocator = SpyAllocator::default();
-
-    let storage = SingleRange::new(allocator.clone());
-    let mut vec = Vec::new(storage);
-
-    assert_eq!(0, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
-
-    for i in 0..31 {
-        vec.push(i);
-
-        assert_eq!(allocator.allocated() - 1, allocator.deallocated());
+        assert_eq!(mem::size_of::<usize>() * 3, mem::size_of::<Vec>());
     }
 
-    assert_eq!(Some(&2), vec.get(2));
+    #[test]
+    fn smoke_test() {
+        type Storage = SingleRange<SpyAllocator>;
+        type Vec = RawVec<u8, Storage>;
 
-    assert_eq!(
+        let allocator = SpyAllocator::default();
+
+        let storage = SingleRange::new(allocator.clone());
+        let mut vec = Vec::new(storage);
+
+        assert_eq!(0, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
+
+        for i in 0..31 {
+            vec.push(i);
+
+            assert_eq!(allocator.allocated() - 1, allocator.deallocated());
+        }
+
+        assert_eq!(Some(&2), vec.get(2));
+
+        assert_eq!(
         "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]",
         format!("{:?}", vec)
     );
 
-    mem::drop(vec);
+        mem::drop(vec);
 
-    assert_eq!(6, allocator.allocated());
-    assert_eq!(6, allocator.deallocated());
-}
+        assert_eq!(6, allocator.allocated());
+        assert_eq!(6, allocator.deallocated());
+    }
 
-#[test]
-fn try_push_failure() {
-    type Storage = SingleRange<NonAllocator>;
-    type Vec = RawVec<u8, Storage>;
+    #[test]
+    fn try_push_failure() {
+        type Storage = SingleRange<NonAllocator>;
+        type Vec = RawVec<u8, Storage>;
 
-    let mut vec = Vec::default();
+        let mut vec = Vec::default();
 
-    assert_eq!(Err(42), vec.try_push(42));
-}
-
+        assert_eq!(Err(42), vec.try_push(42));
+    }
 } // mod test_allocator

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -191,7 +191,10 @@ where
                     Ok(handle) => Ok(Primary(handle)),
                     Err(_) => {
                         let second = self.secondary.allocate(new_capacity)?;
-                        transfer(self.primary.resolve_mut(first), self.secondary.resolve_mut(second));
+                        transfer(
+                            self.primary.resolve_mut(first),
+                            self.secondary.resolve_mut(second),
+                        );
                         self.primary.deallocate(first);
                         Ok(Secondary(second))
                     }
@@ -218,7 +221,10 @@ where
                 .map(|handle| Primary(handle)),
             Secondary(second) => {
                 if let Ok(first) = first_capacity.and_then(|cap| self.primary.allocate(cap)) {
-                    transfer(self.secondary.resolve_mut(second), self.primary.resolve_mut(first));
+                    transfer(
+                        self.secondary.resolve_mut(second),
+                        self.primary.resolve_mut(first),
+                    );
                     self.secondary.deallocate(second);
                     Ok(Primary(first))
                 } else {

--- a/src/inline/single_range.rs
+++ b/src/inline/single_range.rs
@@ -1,8 +1,18 @@
 //! Simple implementation of `SingleRangeStorage`.
 
-use core::{alloc::AllocError, cmp, fmt::{self, Debug}, marker::PhantomData, mem::{self, MaybeUninit}, ptr::NonNull};
+use core::{
+    alloc::AllocError,
+    cmp,
+    fmt::{self, Debug},
+    marker::PhantomData,
+    mem::{self, MaybeUninit},
+    ptr::NonNull,
+};
 
-use crate::{traits::{Capacity, RangeStorage, SingleRangeStorage}, utils};
+use crate::{
+    traits::{Capacity, RangeStorage, SingleRangeStorage},
+    utils,
+};
 
 /// Generic inline SingleRangeStorage.
 ///
@@ -14,7 +24,12 @@ pub struct SingleRange<C, S, const N: usize> {
 
 impl<C, S, const N: usize> SingleRange<C, S, N> {
     /// Creates an instance of SingleRange.
-    pub fn new() -> Self { Self { data: MaybeUninit::uninit_array(), _marker: PhantomData, } }
+    pub fn new() -> Self {
+        Self {
+            data: [const { MaybeUninit::uninit() }; N],
+            _marker: PhantomData,
+        }
+    }
 }
 
 impl<C: Capacity, S, const N: usize> RangeStorage for SingleRange<C, S, N> {
@@ -63,19 +78,24 @@ impl<C, S, const N: usize> Debug for SingleRange<C, S, N> {
 }
 
 impl<C, S, const N: usize> Default for SingleRange<C, S, N> {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
-
 /// Handle of SingleRange.
-pub struct SingleRangeHandle<T>(PhantomData<fn(T)->T>);
+pub struct SingleRangeHandle<T>(PhantomData<fn(T) -> T>);
 
 impl<T> SingleRangeHandle<T> {
-    fn new() -> Self { Self(PhantomData) }
+    fn new() -> Self {
+        Self(PhantomData)
+    }
 }
 
 impl<T> Clone for SingleRangeHandle<T> {
-    fn clone(&self) -> Self { *self }
+    fn clone(&self) -> Self {
+        *self
+    }
 }
 
 impl<T> Copy for SingleRangeHandle<T> {}
@@ -89,29 +109,28 @@ impl<T> Debug for SingleRangeHandle<T> {
 #[cfg(test)]
 mod tests {
 
-use super::*;
+    use super::*;
 
-#[test]
-fn new_unconditional_success() {
-    SingleRange::<u8, u8, 42>::new();
-}
+    #[test]
+    fn new_unconditional_success() {
+        SingleRange::<u8, u8, 42>::new();
+    }
 
-#[test]
-fn allocate_success() {
-    let mut storage = SingleRange::<u8, u8, 42>::new();
-    storage.allocate::<u8>(2).unwrap();
-}
+    #[test]
+    fn allocate_success() {
+        let mut storage = SingleRange::<u8, u8, 42>::new();
+        storage.allocate::<u8>(2).unwrap();
+    }
 
-#[test]
-fn allocate_insufficient_size() {
-    let mut storage = SingleRange::<u8, u8, 2>::new();
-    storage.allocate::<u8>(3).unwrap_err();
-}
+    #[test]
+    fn allocate_insufficient_size() {
+        let mut storage = SingleRange::<u8, u8, 2>::new();
+        storage.allocate::<u8>(3).unwrap_err();
+    }
 
-#[test]
-fn allocate_insufficient_alignment() {
-    let mut storage = SingleRange::<u8, u8, 42>::new();
-    storage.allocate::<u32>(1).unwrap_err();
-}
-
+    #[test]
+    fn allocate_insufficient_alignment() {
+        let mut storage = SingleRange::<u8, u8, 42>::new();
+        storage.allocate::<u32>(1).unwrap_err();
+    }
 } // mod tests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,12 @@
 #![cfg_attr(not(test), no_std)]
-
 //  Language Features
 #![feature(coerce_unsized)]
 #![feature(ptr_metadata)]
 #![feature(unsize)]
-
 //  Library Features
 #![feature(allocator_api)]
 #![feature(layout_for_ptr)]
-#![feature(maybe_uninit_slice)]
-#![feature(maybe_uninit_uninit_array)]
-#![feature(nonnull_slice_from_raw_parts)]
 #![feature(slice_ptr_get)]
-#![feature(slice_ptr_len)]
-
 //  Lints
 #![deny(missing_docs)]
 

--- a/src/small/single_element.rs
+++ b/src/small/single_element.rs
@@ -1,6 +1,11 @@
 //! Small implementation of `SingleElementStorage`.
 
-use core::{alloc::{Allocator, AllocError}, fmt::{self, Debug}, marker::Unsize, ptr::{NonNull, Pointee}};
+use core::{
+    alloc::{AllocError, Allocator},
+    fmt::{self, Debug},
+    marker::Unsize,
+    ptr::{NonNull, Pointee},
+};
 
 use crate::{
     allocator::{self, AllocatorBuilder},
@@ -18,7 +23,11 @@ pub struct SingleElement<S, A> {
 
 impl<S: Default, A> SingleElement<S, A> {
     /// Create new instance.
-    pub fn new(allocator: A) -> Self { Self { inner: Inner::first(Default::default(), AllocatorBuilder(allocator)) } }
+    pub fn new(allocator: A) -> Self {
+        Self {
+            inner: Inner::first(Default::default(), AllocatorBuilder(allocator)),
+        }
+    }
 }
 
 impl<S, A: Allocator> ElementStorage for SingleElement<S, A> {
@@ -36,7 +45,10 @@ impl<S, A: Allocator> ElementStorage for SingleElement<S, A> {
         self.inner.resolve_mut(handle)
     }
 
-    unsafe fn coerce<U: ?Sized + Pointee, T: ?Sized + Pointee + Unsize<U>>(&self, handle: Self::Handle<T>) -> Self::Handle<U> {
+    unsafe fn coerce<U: ?Sized + Pointee, T: ?Sized + Pointee + Unsize<U>>(
+        &self,
+        handle: Self::Handle<T>,
+    ) -> Self::Handle<U> {
         self.inner.coerce(handle)
     }
 }
@@ -46,7 +58,10 @@ impl<S, A: Allocator> SingleElementStorage for SingleElement<S, A> {
         self.inner.create(value)
     }
 
-    fn allocate<T: ?Sized + Pointee>(&mut self, meta: T::Metadata) -> Result<Self::Handle<T>, AllocError> {
+    fn allocate<T: ?Sized + Pointee>(
+        &mut self,
+        meta: T::Metadata,
+    ) -> Result<Self::Handle<T>, AllocError> {
         self.inner.allocate(meta)
     }
 }
@@ -58,84 +73,88 @@ impl<S, A> Debug for SingleElement<S, A> {
 }
 
 impl<S: Default, A: Default> Default for SingleElement<S, A> {
-    fn default() -> Self { Self::new(A::default()) }
+    fn default() -> Self {
+        Self::new(A::default())
+    }
 }
-
 
 //
 //  Implementation
 //
 
-type Inner<S, A> =
-    alternative::SingleElement<inline::SingleElement<S>, allocator::SingleElement<A>, DefaultBuilder, AllocatorBuilder<A>>;
+type Inner<S, A> = alternative::SingleElement<
+    inline::SingleElement<S>,
+    allocator::SingleElement<A>,
+    DefaultBuilder,
+    AllocatorBuilder<A>,
+>;
 
 #[cfg(test)]
 mod tests {
 
-use crate::utils::{NonAllocator, SpyAllocator};
+    use crate::utils::{NonAllocator, SpyAllocator};
 
-use super::*;
+    use super::*;
 
-#[test]
-fn default_unconditional_success() {
-    SingleElement::<u8, NonAllocator>::default();
-}
+    #[test]
+    fn default_unconditional_success() {
+        SingleElement::<u8, NonAllocator>::default();
+    }
 
-#[test]
-fn new_unconditional_success() {
-    SingleElement::<u8, _>::new(NonAllocator);
-}
+    #[test]
+    fn new_unconditional_success() {
+        SingleElement::<u8, _>::new(NonAllocator);
+    }
 
-#[test]
-fn create_inline_success() {
-    let mut storage = SingleElement::<[u8; 2], _>::new(NonAllocator);
-    storage.create(1u8).unwrap();
-}
+    #[test]
+    fn create_inline_success() {
+        let mut storage = SingleElement::<[u8; 2], _>::new(NonAllocator);
+        storage.create(1u8).unwrap();
+    }
 
-#[test]
-fn create_allocated_success() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn create_allocated_success() {
+        let allocator = SpyAllocator::default();
 
-    let mut storage = SingleElement::<u8, _>::new(allocator.clone());
-    let handle = storage.create(1u32).unwrap();
+        let mut storage = SingleElement::<u8, _>::new(allocator.clone());
+        let handle = storage.create(1u32).unwrap();
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    unsafe { storage.destroy(handle) };
+        unsafe { storage.destroy(handle) };
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 
-#[test]
-fn create_insufficient_size() {
-    let mut storage = SingleElement::<u8, _>::new(NonAllocator);
-    storage.create([1u8, 2]).unwrap_err();
-}
+    #[test]
+    fn create_insufficient_size() {
+        let mut storage = SingleElement::<u8, _>::new(NonAllocator);
+        storage.create([1u8, 2]).unwrap_err();
+    }
 
-#[test]
-fn create_insufficient_alignment() {
-    let mut storage = SingleElement::<[u8; 32], _>::new(NonAllocator);
-    storage.create(1u32).unwrap_err();
-}
+    #[test]
+    fn create_insufficient_alignment() {
+        let mut storage = SingleElement::<[u8; 32], _>::new(NonAllocator);
+        storage.create(1u32).unwrap_err();
+    }
 
-#[test]
-fn coerce_allocated() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn coerce_allocated() {
+        let allocator = SpyAllocator::default();
 
-    let mut storage = SingleElement::<u8, _>::new(allocator.clone());
-    let handle = storage.create([1u32, 2, 3]).unwrap();
+        let mut storage = SingleElement::<u8, _>::new(allocator.clone());
+        let handle = storage.create([1u32, 2, 3]).unwrap();
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    let handle = unsafe { storage.coerce::<[u32], _>(handle) };
+        let handle = unsafe { storage.coerce::<[u32], _>(handle) };
 
-    unsafe { storage.destroy(handle) };
+        unsafe { storage.destroy(handle) };
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
-
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 } // mod tests

--- a/src/small/single_range.rs
+++ b/src/small/single_range.rs
@@ -1,6 +1,11 @@
 //! Small implementation of `SingleRangeStorage`.
 
-use core::{alloc::{Allocator, AllocError}, fmt::{self, Debug}, mem::MaybeUninit, ptr::NonNull};
+use core::{
+    alloc::{AllocError, Allocator},
+    fmt::{self, Debug},
+    mem::MaybeUninit,
+    ptr::NonNull,
+};
 
 use crate::{
     allocator::{self, AllocatorBuilder},
@@ -18,7 +23,11 @@ pub struct SingleRange<S, A> {
 
 impl<S: Default, A> SingleRange<S, A> {
     /// Create new instance.
-    pub fn new(allocator: A) -> Self { Self { inner: Inner::first(Default::default(), AllocatorBuilder(allocator)) } }
+    pub fn new(allocator: A) -> Self {
+        Self {
+            inner: Inner::first(Default::default(), AllocatorBuilder(allocator)),
+        }
+    }
 }
 
 impl<S, A: Allocator> RangeStorage for SingleRange<S, A> {
@@ -26,7 +35,9 @@ impl<S, A: Allocator> RangeStorage for SingleRange<S, A> {
 
     type Capacity = <Inner<S, A> as RangeStorage>::Capacity;
 
-    fn maximum_capacity<T>(&self) -> Self::Capacity { self.inner.maximum_capacity::<T>() }
+    fn maximum_capacity<T>(&self) -> Self::Capacity {
+        self.inner.maximum_capacity::<T>()
+    }
 
     unsafe fn deallocate<T>(&mut self, handle: Self::Handle<T>) {
         self.inner.deallocate(handle)
@@ -40,11 +51,19 @@ impl<S, A: Allocator> RangeStorage for SingleRange<S, A> {
         self.inner.resolve_mut(handle)
     }
 
-    unsafe fn try_grow<T>(&mut self, handle: Self::Handle<T>, new_capacity: Self::Capacity) -> Result<Self::Handle<T>, AllocError> {
+    unsafe fn try_grow<T>(
+        &mut self,
+        handle: Self::Handle<T>,
+        new_capacity: Self::Capacity,
+    ) -> Result<Self::Handle<T>, AllocError> {
         self.inner.try_grow(handle, new_capacity)
     }
 
-    unsafe fn try_shrink<T>(&mut self, handle: Self::Handle<T>, new_capacity: Self::Capacity) -> Result<Self::Handle<T>, AllocError> {
+    unsafe fn try_shrink<T>(
+        &mut self,
+        handle: Self::Handle<T>,
+        new_capacity: Self::Capacity,
+    ) -> Result<Self::Handle<T>, AllocError> {
         self.inner.try_shrink(handle, new_capacity)
     }
 }
@@ -62,63 +81,67 @@ impl<S, A> Debug for SingleRange<S, A> {
 }
 
 impl<S: Default, A: Default> Default for SingleRange<S, A> {
-    fn default() -> Self { Self::new(A::default()) }
+    fn default() -> Self {
+        Self::new(A::default())
+    }
 }
-
 
 //
 //  Implementation
 //
 
-type Inner<S, A> =
-    alternative::SingleRange<inline::SingleRange<usize, S, 1>, allocator::SingleRange<A>, DefaultBuilder, AllocatorBuilder<A>>;
+type Inner<S, A> = alternative::SingleRange<
+    inline::SingleRange<usize, S, 1>,
+    allocator::SingleRange<A>,
+    DefaultBuilder,
+    AllocatorBuilder<A>,
+>;
 
 #[cfg(test)]
 mod tests {
 
-use crate::utils::{NonAllocator, SpyAllocator};
+    use crate::utils::{NonAllocator, SpyAllocator};
 
-use super::*;
+    use super::*;
 
-#[test]
-fn default_unconditional_success() {
-    SingleRange::<u8, NonAllocator>::default();
-}
+    #[test]
+    fn default_unconditional_success() {
+        SingleRange::<u8, NonAllocator>::default();
+    }
 
-#[test]
-fn new_unconditional_success() {
-    SingleRange::<u8, _>::new(NonAllocator);
-}
+    #[test]
+    fn new_unconditional_success() {
+        SingleRange::<u8, _>::new(NonAllocator);
+    }
 
-#[test]
-fn allocate_zero_success() {
-    let mut storage = SingleRange::<[u8; 2], _>::new(NonAllocator);
+    #[test]
+    fn allocate_zero_success() {
+        let mut storage = SingleRange::<[u8; 2], _>::new(NonAllocator);
 
-    let handle = storage.allocate::<String>(0).unwrap();
+        let handle = storage.allocate::<String>(0).unwrap();
 
-    assert_eq!(0, unsafe { storage.resolve(handle) }.len());
-}
+        assert_eq!(0, unsafe { storage.resolve(handle) }.len());
+    }
 
-#[test]
-fn allocate_success() {
-    let allocator = SpyAllocator::default();
+    #[test]
+    fn allocate_success() {
+        let allocator = SpyAllocator::default();
 
-    let mut storage = SingleRange::<[u8; 2], _>::new(allocator.clone());
-    let handle = storage.allocate::<String>(1).unwrap();
+        let mut storage = SingleRange::<[u8; 2], _>::new(allocator.clone());
+        let handle = storage.allocate::<String>(1).unwrap();
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(0, allocator.deallocated());
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(0, allocator.deallocated());
 
-    unsafe { storage.deallocate(handle) };
+        unsafe { storage.deallocate(handle) };
 
-    assert_eq!(1, allocator.allocated());
-    assert_eq!(1, allocator.deallocated());
-}
+        assert_eq!(1, allocator.allocated());
+        assert_eq!(1, allocator.deallocated());
+    }
 
-#[test]
-fn allocate_failure() {
-    let mut storage = SingleRange::<[u8; 2], _>::new(NonAllocator);
-    storage.allocate::<String>(1).unwrap_err();
-}
-
+    #[test]
+    fn allocate_failure() {
+        let mut storage = SingleRange::<[u8; 2], _>::new(NonAllocator);
+        storage.allocate::<String>(1).unwrap_err();
+    }
 } // mod tests

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,12 @@
 //! The various storages available.
 
-use core::{alloc::AllocError, convert::TryInto, marker::Unsize, mem::MaybeUninit, ptr::{self, NonNull, Pointee}};
+use core::{
+    alloc::AllocError,
+    convert::TryInto,
+    marker::Unsize,
+    mem::MaybeUninit,
+    ptr::{self, NonNull, Pointee},
+};
 
 //
 //  Element Storage
@@ -14,7 +20,7 @@ use core::{alloc::AllocError, convert::TryInto, marker::Unsize, mem::MaybeUninit
 /// -   `MultiElementStorage`, which may store multiple elements at any one time.
 pub trait ElementStorage {
     /// The Handle used to obtain the elements.
-    type Handle<T: ?Sized + Pointee> : Clone + Copy;
+    type Handle<T: ?Sized + Pointee>: Clone + Copy;
 
     /// Destroys the value stored within the storage.
     ///
@@ -65,14 +71,16 @@ pub trait ElementStorage {
     /// #   Safety
     ///
     /// -   Assumes that `handle` is valid, and was issued by this instance.
-    unsafe fn coerce<U: ?Sized + Pointee, T: ?Sized + Pointee + Unsize<U>>(&self, handle: Self::Handle<T>) -> Self::Handle<U>;
-
+    unsafe fn coerce<U: ?Sized + Pointee, T: ?Sized + Pointee + Unsize<U>>(
+        &self,
+        handle: Self::Handle<T>,
+    ) -> Self::Handle<U>;
 }
 
 /// A single element storage.
 ///
 /// Examples of use include: Box.
-pub trait SingleElementStorage : ElementStorage {
+pub trait SingleElementStorage: ElementStorage {
     /// Stores a `value` within the storage.
     ///
     /// If a value is already stored, it is overwritten and `drop` is not executed.
@@ -99,13 +107,16 @@ pub trait SingleElementStorage : ElementStorage {
     /// This may fail if memory cannot be allocated for it.
     ///
     /// If a value is already stored, the memory area may overlap.
-    fn allocate<T: ?Sized + Pointee>(&mut self, meta: T::Metadata) -> Result<Self::Handle<T>, AllocError>;
+    fn allocate<T: ?Sized + Pointee>(
+        &mut self,
+        meta: T::Metadata,
+    ) -> Result<Self::Handle<T>, AllocError>;
 }
 
 /// A multi elements storage.
 ///
 /// Examples of use include: BTreeMap, LinkedList, SkipList.
-pub trait MultiElementStorage : ElementStorage{
+pub trait MultiElementStorage: ElementStorage {
     /// Attempts to store `value` in a newly allocated memory slot.
     ///
     /// This may fail if memory cannot be allocated for it.
@@ -136,7 +147,10 @@ pub trait MultiElementStorage : ElementStorage{
     /// Allocates memory, and returns a handle to it.
     ///
     /// This may fail if memory cannot be allocated for it.
-    fn allocate<T: ?Sized + Pointee>(&mut self, meta: T::Metadata) -> Result<Self::Handle<T>, AllocError>;
+    fn allocate<T: ?Sized + Pointee>(
+        &mut self,
+        meta: T::Metadata,
+    ) -> Result<Self::Handle<T>, AllocError>;
 }
 
 //
@@ -144,7 +158,7 @@ pub trait MultiElementStorage : ElementStorage{
 //
 
 /// Capacity type for range storage.
-pub trait Capacity : Sized + Clone + Copy {
+pub trait Capacity: Sized + Clone + Copy {
     /// The maximum possible value of this type.
     fn max() -> Self;
 
@@ -163,12 +177,12 @@ pub trait Capacity : Sized + Clone + Copy {
 /// -   `MultiRangeStorage`, which may store multiple ranges at any one time.
 pub trait RangeStorage {
     /// The Handle used to obtain the range.
-    type Handle<T> : Clone + Copy;
+    type Handle<T>: Clone + Copy;
 
     /// The Capacity type used by the storage.
     ///
     /// The collection may which to use it for related values to keep them as compact as possible.
-    type Capacity : Capacity;
+    type Capacity: Capacity;
 
     /// Indicates the maximum capacity of a single range possibly available for an element of type `T`.
     fn maximum_capacity<T>(&self) -> Self::Capacity;
@@ -205,14 +219,22 @@ pub trait RangeStorage {
     /// Attempts to grow the internal storage to accomodate at least `new_capacity` elements in total.
     ///
     /// If the attempt succeeds, a new handle is returned and `handle` is invalidated.
-    unsafe fn try_grow<T>(&mut self, _handle: Self::Handle<T>, _new_capacity: Self::Capacity) -> Result<Self::Handle<T>, AllocError> {
+    unsafe fn try_grow<T>(
+        &mut self,
+        _handle: Self::Handle<T>,
+        _new_capacity: Self::Capacity,
+    ) -> Result<Self::Handle<T>, AllocError> {
         Err(AllocError)
     }
 
     /// Attempts to shrink the internal storage to accomodate at least `new_capacity` elements in total.
     ///
     /// If the attempt succeeds, a new handle is returned and `handle` is invalidated.
-    unsafe fn try_shrink<T>(&mut self, _handle: Self::Handle<T>, _new_capacity: Self::Capacity) -> Result<Self::Handle<T>, AllocError> {
+    unsafe fn try_shrink<T>(
+        &mut self,
+        _handle: Self::Handle<T>,
+        _new_capacity: Self::Capacity,
+    ) -> Result<Self::Handle<T>, AllocError> {
         Err(AllocError)
     }
 }
@@ -220,7 +242,7 @@ pub trait RangeStorage {
 /// A single range storage.
 ///
 /// Examples of use include: Vec, VecDeque.
-pub trait SingleRangeStorage : RangeStorage {
+pub trait SingleRangeStorage: RangeStorage {
     /// Allocates memory for a new `Handle`, large enough to at least accomodate the required `capacity`.
     ///
     /// Does not `deallocate` the current handles, nor drop their content. It merely invalidates them.
@@ -230,7 +252,7 @@ pub trait SingleRangeStorage : RangeStorage {
 /// A multi elements storage.
 ///
 /// Examples of use include: CompactHashMap.
-pub trait MultiRangeStorage : RangeStorage{
+pub trait MultiRangeStorage: RangeStorage {
     /// Allocates memory for a new `Handle`, large enough to at least accomodate the required `capacity`.
     ///
     /// This may fail if memory cannot be allocated for it.
@@ -243,40 +265,63 @@ pub trait MultiRangeStorage : RangeStorage{
     fn allocate<T>(&mut self, capacity: Self::Capacity) -> Result<Self::Handle<T>, AllocError>;
 }
 
-
 //
 //  Implementations of Capacity.
 //
 
 impl Capacity for usize {
-    fn max() -> usize { usize::MAX }
+    fn max() -> usize {
+        usize::MAX
+    }
 
-    fn from_usize(capacity: usize) -> Option<Self> { Some(capacity) }
+    fn from_usize(capacity: usize) -> Option<Self> {
+        Some(capacity)
+    }
 
-    fn into_usize(self) -> usize { self }
+    fn into_usize(self) -> usize {
+        self
+    }
 }
 
 impl Capacity for u8 {
-    fn max() -> Self { u8::MAX }
+    fn max() -> Self {
+        u8::MAX
+    }
 
-    fn from_usize(capacity: usize) -> Option<Self> { capacity.try_into().ok() }
+    fn from_usize(capacity: usize) -> Option<Self> {
+        capacity.try_into().ok()
+    }
 
-    fn into_usize(self) -> usize { self as usize }
+    fn into_usize(self) -> usize {
+        self as usize
+    }
 }
 
 impl Capacity for u16 {
-    fn max() -> Self { u16::MAX }
+    fn max() -> Self {
+        u16::MAX
+    }
 
-    fn from_usize(capacity: usize) -> Option<Self> { capacity.try_into().ok() }
+    fn from_usize(capacity: usize) -> Option<Self> {
+        capacity.try_into().ok()
+    }
 
-    fn into_usize(self) -> usize { self as usize }
+    fn into_usize(self) -> usize {
+        self as usize
+    }
 }
 
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl Capacity for u32 {
-    fn max() -> Self { u32::MAX }
+    fn max() -> Self {
+        u32::MAX
+    }
 
-    fn from_usize(capacity: usize) -> Option<Self> { capacity.try_into().ok() }
+    fn from_usize(capacity: usize) -> Option<Self> {
+        capacity.try_into().ok()
+    }
 
-    fn into_usize(self)-> usize { self as usize }
+    fn into_usize(self) -> usize {
+        self as usize
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,12 @@
 //! Various utilities.
 
-use core::{alloc::{AllocError, Layout}, fmt::{self, Debug}, marker::PhantomData, mem, ptr::{self, Pointee}};
+use core::{
+    alloc::{AllocError, Layout},
+    fmt::{self, Debug},
+    marker::PhantomData,
+    mem,
+    ptr::{self, Pointee},
+};
 
 #[cfg(test)]
 pub(crate) use test::*;
@@ -15,16 +21,16 @@ impl<T: ?Sized> Debug for PhantomInvariant<T> {
 }
 
 impl<T: ?Sized> Default for PhantomInvariant<T> {
-    fn default() -> Self { Self(PhantomData) }
+    fn default() -> Self {
+        Self(PhantomData)
+    }
 }
 
 /// Computes the layout for a value with metadata `meta`.
-pub fn layout_of<T: ?Sized + Pointee>(meta: T::Metadata) -> Layout {
-    let pointer: *const T = ptr::from_raw_parts(ptr::null_mut(), meta);
-
+pub fn layout_of<T: ?Sized>(metadata: <T as Pointee>::Metadata) -> Layout {
     //  Safety:
     //  -   `meta` is valid.
-    unsafe { Layout::for_value_raw(pointer) }
+    unsafe { Layout::for_value_raw(ptr::from_raw_parts::<T>(ptr::null::<()>(), metadata)) }
 }
 
 /// Validates that the layout of `storage` is sufficient to accomodate an instance of `T`.
@@ -58,38 +64,48 @@ pub fn validate_layout_for<Storage>(layout: Layout) -> Result<(), AllocError> {
 #[cfg(test)]
 mod test {
 
-use core::{cell::Cell, ptr::NonNull};
+    use core::{cell::Cell, ptr::NonNull};
 
-use std::{alloc::{Allocator, AllocError, Global, Layout}, rc::Rc};
+    use std::{
+        alloc::{AllocError, Allocator, Global, Layout},
+        rc::Rc,
+    };
 
-//  A NonAllocator never allocates.
-#[derive(Debug, Default)]
-pub(crate) struct NonAllocator;
+    //  A NonAllocator never allocates.
+    #[derive(Debug, Default)]
+    pub(crate) struct NonAllocator;
 
-unsafe impl Allocator for NonAllocator {
-    fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, AllocError> { Err(AllocError) }
-    unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) { panic!("NonAllocator::deallocate called!") }
-}
-
-#[derive(Clone, Debug, Default)]
-pub(crate) struct SpyAllocator(Rc<(Cell<usize>, Cell<usize>)>);
-
-impl SpyAllocator {
-    pub(crate) fn allocated(&self) -> usize { self.0.0.get() }
-
-    pub(crate) fn deallocated(&self) -> usize { self.0.1.get() }
-}
-
-unsafe impl Allocator for SpyAllocator {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        self.0.0.set(self.0.0.get() + 1);
-        Global.allocate(layout)
+    unsafe impl Allocator for NonAllocator {
+        fn allocate(&self, _layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            Err(AllocError)
+        }
+        unsafe fn deallocate(&self, _ptr: NonNull<u8>, _layout: Layout) {
+            panic!("NonAllocator::deallocate called!")
+        }
     }
 
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        self.0.1.set(self.0.1.get() + 1);
-        Global.deallocate(ptr, layout)
-    }
-}
+    #[derive(Clone, Debug, Default)]
+    pub(crate) struct SpyAllocator(Rc<(Cell<usize>, Cell<usize>)>);
 
+    impl SpyAllocator {
+        pub(crate) fn allocated(&self) -> usize {
+            self.0 .0.get()
+        }
+
+        pub(crate) fn deallocated(&self) -> usize {
+            self.0 .1.get()
+        }
+    }
+
+    unsafe impl Allocator for SpyAllocator {
+        fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+            self.0 .0.set(self.0 .0.get() + 1);
+            Global.allocate(layout)
+        }
+
+        unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+            self.0 .1.set(self.0 .1.get() + 1);
+            Global.deallocate(ptr, layout)
+        }
+    }
 } // mod test


### PR DESCRIPTION
Wanted to play around a bit so I ported the code to the latest nightly.
First commit are fixes for the newest nightly and some format stuff (autosave).
Second commit is a full `cargo fmt`.

Is there still interest in maybe using this instead of the allocator api?